### PR TITLE
Fix Cannot use $this as parameter

### DIFF
--- a/inc/computer.class.php
+++ b/inc/computer.class.php
@@ -40,7 +40,7 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginExampleComputer extends CommonDBTM {
 
-   static function showInfo($this) {
+   static function showInfo() {
 
       echo '<table class="tab_glpi" width="100%">';
       echo '<tr>';


### PR DESCRIPTION
I saw this in my php logs (PHP-FPM 7.1):
```
Fatal error:  Cannot use $this as parameter in /var/www/webapps/glpi/plugins/example/inc/computer.class.php on line 43
```