### PR TITLE
Add usage of *_item_form hooks

### DIFF
--- a/inc/itemform.class.php
+++ b/inc/itemform.class.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ -------------------------------------------------------------------------
+GLPI - Gestionnaire Libre de Parc Informatique
+Copyright (C) 2003-2011 by the INDEPNET Development Team.
+
+http://indepnet.net/   http://glpi-project.org
+-------------------------------------------------------------------------
+
+LICENSE
+
+This file is part of GLPI.
+
+GLPI is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+GLPI is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+--------------------------------------------------------------------------
+ */
+
+/**
+ * Summary of PluginExampleItemForm
+ * Example of *_item_form implementation
+ * @see http://glpi-developer-documentation.rtfd.io/en/master/plugins/hooks.html#items-display-related
+ * */
+class PluginExampleItemForm {
+
+   /**
+    * Display contents at the begining of item forms.
+    *
+    * @param array $params Array with "item" and "options" keys
+    *
+    * @return void
+    */
+   static public function preItemForm($params) {
+      $item = $params['item'];
+      $options = $params['options'];
+
+      $firstelt = ($item::getType() == Ticket::getType() ? 'th' : 'td');
+
+      $out = '<tr><th colspan="' . (isset($options['colspan']) ? $options['colspan'] * 2 : '4') . '">';
+      $out .= sprintf(
+         __('Start %1$s hook call for %2$s type'),
+         'pre_item_form',
+         $item::getType()
+      );
+      $out .= '</th></tr>';
+
+      $out .= "<tr><$firstelt>";
+      $out .= '<label for="example_pre_form_hook">' . __('First pre form hook') . '</label>';
+      $out .= "</$firstelt><td>";
+      $out .= '<input type="text" name="example_pre_form_hook" id="example_pre_form_hook"/>';
+      $out .= "</td><$firstelt>";
+      $out .= '<label for="example_pre_form_hook2">' . __('Second pre form hook') . '</label>';
+      $out .= "</$firstelt><td>";
+      $out .= '<input type="text" name="example_pre_form_hook2" id="example_pre_form_hook2"/>';
+      $out .= '</td></tr>';
+
+      $out .= '<tr><th colspan="' . (isset($options['colspan']) ? $options['colspan'] * 2 : '4') . '">';
+      $out .= sprintf(
+         __('End %1$s hook call for %2$s type'),
+         'pre_item_form',
+         $item::getType()
+      );
+      $out .= '</th></tr>';
+
+      echo $out;
+   }
+
+   /**
+    * Display contents at the begining of item forms.
+    *
+    * @param array $params Array with "item" and "options" keys
+    *
+    * @return void
+    */
+   static public function postItemForm($params) {
+      $item = $params['item'];
+      $options = $params['options'];
+
+      $firstelt = ($item::getType() == Ticket::getType() ? 'th' : 'td');
+
+      $out = '<tr><th colspan="' . (isset($options['colspan']) ? $options['colspan'] * 2 : '4') . '">';
+      $out .= sprintf(
+         __('Start %1$s hook call for %2$s type'),
+         'post_item_form',
+         $item::getType()
+      );
+      $out .= '</th></tr>';
+
+      $out .= "<tr><$firstelt>";
+      $out .= '<label for="example_post_form_hook">' . __('First post form hook') . '</label>';
+      $out .= "</$firstelt><td>";
+      $out .= '<input type="text" name="example_post_form_hook" id="example_post_form_hook"/>';
+      $out .= "</td><$firstelt>";
+      $out .= '<label for="example_post_form_hook2">' . __('Second post form hook') . '</label>';
+      $out .= "</$firstelt><td>";
+      $out .= '<input type="text" name="example_post_form_hook2" id="example_post_form_hook2"/>';
+      $out .= '</td></tr>';
+
+      $out .= '<tr><th colspan="' . (isset($options['colspan']) ? $options['colspan'] * 2 : '4') . '">';
+      $out .= sprintf(
+         __('End %1$s hook call for %2$s type'),
+         'post_item_form',
+         $item::getType()
+      );
+      $out .= '</th></tr>';
+
+      echo $out;
+   }
+}

--- a/setup.php
+++ b/setup.php
@@ -186,10 +186,13 @@ function plugin_init_example() {
 
    // pre_show and post_show for tabs and items,
    // see PluginExampleShowtabitem class for implementation explanations
-   $PLUGIN_HOOKS['pre_show_tab']['example'] = array( 'PluginExampleShowtabitem',  'pre_show_tab' );
-   $PLUGIN_HOOKS['post_show_tab']['example'] = array( 'PluginExampleShowtabitem',  'post_show_tab' );
-   $PLUGIN_HOOKS['pre_show_item']['example'] = array( 'PluginExampleShowtabitem',  'pre_show_item' );
-   $PLUGIN_HOOKS['post_show_item']['example'] = array( 'PluginExampleShowtabitem',  'post_show_item' );
+   $PLUGIN_HOOKS['pre_show_tab']['example']     = array('PluginExampleShowtabitem', 'pre_show_tab');
+   $PLUGIN_HOOKS['post_show_tab']['example']    = array('PluginExampleShowtabitem', 'post_show_tab');
+   $PLUGIN_HOOKS['pre_show_item']['example']    = array('PluginExampleShowtabitem', 'pre_show_item');
+   $PLUGIN_HOOKS['post_show_item']['example']   = array('PluginExampleShowtabitem', 'post_show_item');
+
+   $PLUGIN_HOOKS['pre_item_form']['example']    = ['PluginExampleItemForm', 'preItemForm'];
+   $PLUGIN_HOOKS['post_item_form']['example']   = ['PluginExampleItemForm', 'postItemForm'];
 
    // declare this plugin as an import plugin for Computer itemtype
    $PLUGIN_HOOKS['import_item']['exemple'] = array('Computer' => array('Plugin'));


### PR DESCRIPTION
This will add an output example for `pre_item_form` and `post_item_form` hooks on each supported itemtype/subtype.