### PR TITLE
Modernize permission handling

### DIFF
--- a/report.php
+++ b/report.php
@@ -40,7 +40,7 @@
 define('GLPI_ROOT', '../..');
 include (GLPI_ROOT . "/inc/includes.php");
 
-Session::checkRight("config", "w");
+Session::checkRight(Config::$rightname, UPDATE);
 
 Html::header("TITRE", $_SERVER['PHP_SELF'], "plugins");
 

--- a/setup.php
+++ b/setup.php
@@ -85,8 +85,8 @@ function plugin_init_example() {
       }
    }
    // Display a menu entry ?
-   $_SESSION["glpi_plugin_example_profile"]['example'] = 'w';
-   if (isset($_SESSION["glpi_plugin_example_profile"])) { // Right set in change_profile hook
+   Plugin::registerClass(\GlpiPlugin\Example\Profile::class, ['addtabon' => ['Profile']]);
+   if (Example::canView()) { // Right set in change_profile hook
       $PLUGIN_HOOKS['menu_toadd']['example'] = ['plugins' => Example::class,
                                                 'tools'   => Example::class];
 

--- a/src/Example.php
+++ b/src/Example.php
@@ -46,43 +46,17 @@ use Session;
 class Example extends CommonDBTM {
 
    static $tags = '[EXAMPLE_ID]';
+   public static $rightname = 'plugin_example';
 
    // Should return the localized name of the type
    static function getTypeName($nb = 0) {
       return 'Example Type';
    }
 
-
-   static function canCreate() {
-
-      if (isset($_SESSION["glpi_plugin_example_profile"])) {
-         return ($_SESSION["glpi_plugin_example_profile"]['example'] == 'w');
-      }
-      return false;
-   }
-
-
-   static function canView() {
-
-      if (isset($_SESSION["glpi_plugin_example_profile"])) {
-         return ($_SESSION["glpi_plugin_example_profile"]['example'] == 'w'
-                 || $_SESSION["glpi_plugin_example_profile"]['example'] == 'r');
-      }
-      return false;
-   }
-
-
-   /**
-    * @see CommonGLPI::getMenuName()
-   **/
    static function getMenuName() {
       return __('Example plugin');
    }
 
-
-   /**
-    * @see CommonGLPI::getAdditionalMenuLinks()
-   **/
    static function getAdditionalMenuLinks() {
       global $CFG_GLPI;
       $links = [];
@@ -406,11 +380,6 @@ class Example extends CommonDBTM {
 
    //////////////////////////////
    ////// SPECIFIC MODIF MASSIVE FUNCTIONS ///////
-   /**
-    * @since version 0.85
-    *
-    * @see CommonDBTM::getSpecificMassiveActions()
-   **/
    function getSpecificMassiveActions($checkitem = null) {
 
       $actions = parent::getSpecificMassiveActions($checkitem);
@@ -423,12 +392,6 @@ class Example extends CommonDBTM {
       return $actions;
    }
 
-
-   /**
-    * @since version 0.85
-    *
-    * @see CommonDBTM::showMassiveActionsSubForm()
-   **/
    static function showMassiveActionsSubForm(MassiveAction $ma) {
 
       switch ($ma->getAction()) {

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Example plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Example.
+ *
+ * Example is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Example is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Example. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2006-2022 by Example plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/example
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Example;
+
+use CommonGLPI;
+use Html;
+use Session;
+
+final class Profile extends \Profile
+{
+    public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
+    {
+        return __('Example plugin');
+    }
+
+    public static function displayTabContentForItem(CommonGLPI $item, $tabnum = 1, $withtemplate = 0)
+    {
+        $profile = new self();
+        $profile->showFormExample($item->getID());
+    }
+
+    public function showFormExample(int $profiles_id): void
+    {
+        if (!$this->can($profiles_id, READ)) {
+            return;
+        }
+
+        echo "<div class='spaced'>";
+
+        $can_edit = Session::haveRight(self::$rightname, UPDATE);
+        if ($can_edit) {
+            echo "<form method='post' action='" . htmlspecialchars(self::getFormURL()) . "'>";
+        }
+
+        $matrix_options = [
+            'canedit' => $can_edit,
+        ];
+        $rights = [
+            [
+                'itemtype' => Example::class,
+                'label' => Example::getTypeName(Session::getPluralNumber()),
+                'field' => Example::$rightname
+            ]
+        ];
+        $matrix_options['title'] = self::getTypeName(1);
+        $this->displayRightsChoiceMatrix($rights, $matrix_options);
+
+        if ($can_edit) {
+            echo "<div class='text-center'>";
+            echo Html::hidden('id', ['value' => $profiles_id]);
+            echo Html::submit(_sx('button', 'Save'), ['name' => 'update']);
+            echo "</div>\n";
+            Html::closeForm();
+        }
+        echo '</div>';
+    }
+}

--- a/stat.php
+++ b/stat.php
@@ -40,7 +40,7 @@
 define('GLPI_ROOT', '../..');
 include (GLPI_ROOT . "/inc/includes.php");
 
-Session::checkRight("config", "w");
+Session::checkRight(Config::$rightname, UPDATE);
 
 Html::header("TITLE", $_SERVER['PHP_SELF'], "plugins");
 


### PR DESCRIPTION
A few weeks ago, I came across someone who was trying to get permissions for their plugin to work by using characters r/w/etc and directly manipulating a session property that isn't used in GLPI. It turned out that this example plugin still showed how permissions were handled over a decade ago.

This PR adds a more modern and working way to handle permissions.